### PR TITLE
Terraform updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,7 +212,7 @@ data "aws_iam_policy_document" "ssm_s3_cwl_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.session_logs_bucket.arn}",
+      aws_s3_bucket.session_logs_bucket.arn,
       "${aws_s3_bucket.session_logs_bucket.arn}/*",
     ]
   }
@@ -225,7 +225,7 @@ data "aws_iam_policy_document" "ssm_s3_cwl_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.session_logs_bucket.arn}",
+      aws_s3_bucket.session_logs_bucket.arn
     ]
   }
 
@@ -255,7 +255,7 @@ data "aws_iam_policy_document" "ssm_s3_cwl_access" {
       "kms:Encrypt",
     ]
 
-    resources = ["${aws_kms_key.ssmkey.arn}"]
+    resources = [aws_kms_key.ssmkey.arn]
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ data "aws_region" "current" {}
 resource "aws_s3_bucket" "session_logs_bucket" {
   bucket                  = var.bucket_name
   acl                     = "private"
-  region                  = data.aws_region.current.name
   force_destroy           = true
   tags                    = var.tags 
 
@@ -55,7 +54,6 @@ resource "aws_s3_bucket_public_access_block" "session_logs_bucket" {
 resource "aws_s3_bucket" "access_log_bucket" {
   bucket                  = var.access_log_bucket_name
   acl                     = "log-delivery-write"
-  region                  = data.aws_region.current.name
   force_destroy           = true
 
   tags                    = var.tags

--- a/vpce.tf
+++ b/vpce.tf
@@ -1,6 +1,6 @@
 data "aws_vpc" "selected" {
   count               = var.vpc_endpoints_enabled ? 1 : 0
-  id                  = "${var.vpc_id}"
+  id                  = var.vpc_id
 }
 
 data "aws_subnet_ids" "selected" {
@@ -30,7 +30,7 @@ resource "aws_security_group" "ssm_sg" {
     from_port         = 443
     to_port           = 443
     protocol          = "tcp"
-    cidr_blocks       = [ "${data.aws_vpc.selected[0].cidr_block}" ]
+    cidr_blocks       = [ data.aws_vpc.selected[0].cidr_block ]
   }
 
   egress {
@@ -52,7 +52,7 @@ resource "aws_vpc_endpoint" "ssm" {
   vpc_endpoint_type   = "Interface"
 
   security_group_ids  = [
-    "${aws_security_group.ssm_sg[0].id}",
+    aws_security_group.ssm_sg[0].id
   ]
 
   private_dns_enabled = true
@@ -67,7 +67,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   vpc_endpoint_type   = "Interface"
 
   security_group_ids  = [
-    "${aws_security_group.ssm_sg[0].id}",
+    aws_security_group.ssm_sg[0].id,
   ]
 
   private_dns_enabled = true
@@ -82,7 +82,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_endpoint_type   = "Interface"
 
   security_group_ids  = [
-    "${aws_security_group.ssm_sg[0].id}",
+    aws_security_group.ssm_sg[0].id,
   ]
 
   private_dns_enabled = true
@@ -120,7 +120,7 @@ resource "aws_vpc_endpoint" "logs" {
   vpc_endpoint_type   = "Interface"
 
   security_group_ids  = [
-    "${aws_security_group.ssm_sg[0].id}",
+    aws_security_group.ssm_sg[0].id
   ]
 
   private_dns_enabled = true
@@ -136,7 +136,7 @@ resource "aws_vpc_endpoint" "kms" {
   vpc_endpoint_type   = "Interface"
 
   security_group_ids  = [
-    "${aws_security_group.ssm_sg[0].id}",
+    aws_security_group.ssm_sg[0].id
   ]
 
   private_dns_enabled = true


### PR DESCRIPTION
- Address interpolation syntax warnings
- Remove region parameter from S3 bucket as it's deprecated and causing errors:

```
Error: Computed attributes cannot be set

  on .terraform/modules/ssm/main.tf line 8, in resource "aws_s3_bucket" "session_logs_bucket":
   8:   region                  = data.aws_region.current.name

Computed attributes cannot be set, but a value was set for "region".


Error: Computed attributes cannot be set

  on .terraform/modules/ssm/main.tf line 58, in resource "aws_s3_bucket" "access_log_bucket":
  58:   region                  = data.aws_region.current.name

Computed attributes cannot be set, but a value was set for "region".
``` 