### PR TITLE
expanded module functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Terraform AWS Session Manager
 
-A Terraform module to setup [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html).  
+A Terraform module to setup [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html).
 
-This module creates the a SSM document to support encrypted session manager communication and logs.  It also creates a KMS key, S3 bucket, and CloudWatch Log group to store logs.  In addition, for EC2 instances without a public IP address it can create VPC endpoints to enable private session manager communication.  However, the VPC endpoint creation can also be facilitated by other modules such as [this](https://github.com/terraform-aws-modules/terraform-aws-vpc).  Be aware of the [AWS PrivateLink pricing](https://aws.amazon.com/privatelink/pricing/) before deployment.  
+This module creates the a SSM document to support encrypted session manager communication and logs. It also creates a KMS key, S3 bucket, and CloudWatch Log group to store logs. In addition, for EC2 instances without a public IP address it can create VPC endpoints to enable private session manager communication. However, the VPC endpoint creation can also be facilitated by other modules such as [this](https://github.com/terraform-aws-modules/terraform-aws-vpc). Be aware of the [AWS PrivateLink pricing](https://aws.amazon.com/privatelink/pricing/) before deployment.
 
 ## Usage
 
@@ -29,62 +29,90 @@ module "ssm" {
   version                   = "0.2.0"
   bucket_name               = "my-session-logs"
   access_log_bucket_name    = "my-session-access-logs"
-  vpc_id                    = "vpc-0dc9ef19c0c23aeaa"
-  tags                      = {
-                                Function = "ssm"
-                              }
   enable_log_to_s3          = true
   enable_log_to_cloudwatch  = true
   vpc_endpoints_enabled     = true
+  vpc_id                    = "vpc-0dc9ef19c0c23aeaa"
+  tags = {
+    Function = "ssm"
+  }
 }
 ```
 
-This module does not create any IAM policies for access to session manager.  To do that, look at example policies in the [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-restrict-access-quickstart.html)
+This module does not create any IAM policies for access to session manager. To do that, look at example policies in the [AWS Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-restrict-access-quickstart.html)
 
+## Notes
 
+In case `Session Manager` has already been accessed using AWS console, `SSM-SessionManagerRunShell` document - which is otherwise managed by this module - may need to be deleted prior to running this module. The following error may occur if the document has not been deleted upfront:
+
+`Error: Error creating SSM document: DocumentAlreadyExists: Document with same name SSM-SessionManagerRunShell already exists`
+
+To delete the document, issue:
+
+`aws ssm delete-document --name SSM-SessionManagerRunShell`
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 1.36 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 1.36 |
 
 ## Inputs
+
 Below is a list of this modules input values:
+
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| bucket\_name | Name of S3 bucket to store session logs | `string` | | yes |
+| bucket\_name | Name of S3 bucket to store session logs | `string` | `ssm-session-logs-<account-id>-<region-id>` | no |
+| bucket\_key\_prefix | Name of S3 sub-folder (prefix) | `string` | | no |
 | log\_archive\_days | Number of days to wait before archiving to Glacier | `number` | `30` | no |
 | log\_expire\_days | Number of days to wait before deleting session logs | `number` | `365` | no |
-| access\_log\_bucket\_name | Name of the S3 bucket to store bucket access logs | `string` | | yes | 
+| access\_log\_bucket\_name | Name of the S3 bucket to store bucket access logs | `string` | `ssm-session-access-logs-<account-id>-<region-id>` | no |
 | access\_log\_expire\_days | Number of days to wait before deleting access logs | `number` | `30` | no |
-| kms\_key\_deletion\_window | Waiting period for scheduled KMS Key deletion.  Can be 7-30 days | `number` | `7` | no |
-| kms\_key\_alias | Alias of the KMS key.  Must start with alias/ followed by a name | `string` | `alias/ssm-key` | no | 
+| kms\_key\_deletion\_window | Number of days to wait for scheduled KMS Key deletion [7-30] | `number` | `7` | no |
+| kms\_key\_alias | Alias of the KMS key. Must start with alias/ followed by a name | `string` | `alias/ssm-key` | no |
 | cloudwatch\_logs\_retention | Number of days to retain Session Logs in CloudWatch | `number` | `30` | no |
 | cloudwatch\_log\_group\_name | Name of the CloudWatch Log Group for storing SSM Session Logs | `string` | `/ssm/session-logs` | no |
-| tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| vpc\_id | VPC ID to deploy endpoints to | `string` | `null` | no |
+| idle\_session\_timeout| Number of minutes a user can be inactive before a session ends [1-60] | `number` | `20` | no |
+| run\_as\_default\_user | OS default user name, if IAM user/role 'SSMSessionRunAs' tag is undefined | `string` | `ssm-user` | no |
+| shell\_profile\_windows | Environment variables, shell preferences, or commands to run when session starts | `string` | | no |
+| shell\_profile\_linux | Environment variables, shell preferences, or commands to run when session starts | `string` | | no |
 | enable\_log\_to\_s3 | Enable Session Manager to Log to S3 | `bool` | `true` | no |
 | enable\_log\_to\_cloudwatch | Enable Session Manager to Log to CloudWatch Logs | `bool` | `true` | no |
+| enable\_run\_as\_user | Enable Run As support for Linux instances | `bool` | `false` | no |
 | vpc\_endpoints\_enabled | Create VPC Endpoints | `bool` | `false` | no |
-
-
+| vpc\_id | VPC ID to deploy endpoints to | `string` | `null` | no |
+| tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
-| Name |  Example Value | Description |
-|------|----------------|-------------|
-| session_logs_bucket_name | my-session-logs | S3 bucket for session logs |
-| access_log_bucket_name | my-session-access-logs | S3 bucket for S3 access logs |
-| cloudwatch_log_group_arn | arn:aws:logs:us-west-2:123456789012:log-group:/ssm/session-logs:* | CloudWatch Log group for session logs |
-| kms_key_arn | arn:aws:kms:us-west-2:123456789012:key/2320fbba-d4e5-420d-82d3-1a4d6b8605e8 | KMS Key Arn for Encrypting logs and session | 
-| iam_role_arn | arn:aws:iam::123456789012:role/ssm_role | IAM Role for EC2 instances |
-| iam_profile_name | ssm_profile | EC2 instance profile for SSM | 
-| ssm_security_group | ["sg-05e4f4cf12db5a191"] | Security Group used to access VPC Endpoints |
-| vpc_endpoint_ssm | ["vpce-0cefc23e81d365733"] | VPC Endpoint for SSM | 
-| vpc_endpoint_ec2messages | ["vpce-0f507468fb9b06b8b"] | VPC Endpoint for EC2 Messages |
-| vpc_endpoint_ssmmessages | ["vpce-0fe2cb670d40ec053"] | VPC Endpoint for SSM Messages |
-| vpc_endpoint_s3 | ["vpce-0a8ebde94fa301a4a"] | VPC Endpoint for S3 |
-| vpc_endpoint_logs | ["vpce-08c90d8df9ef37f90"] | VPC Endpoint for CloudWatch Logs |
-| vpc_endpoint_kms | ["vpce-07ddc11beac1d4a3f"] | VPC Endpoint for KMS |
 
+| Name | Example Value | Description |
+|------|----------------|-------------|
+| session\_logs\_bucket\_name | my-session-logs | S3 bucket for session logs |
+| access\_log\_bucket\_name | my-session-access-logs | S3 bucket for S3 access logs |
+| cloudwatch\_log\_group\_arn | arn:aws:logs:us-west-2:123456789012:log-group:/ssm/session-logs:\* | CloudWatch Log group for session logs |
+| kms\_key\_arn | arn:aws:kms:us-west-2:123456789012:key/2320fbba-d4e5-420d-82d3-1a4d6b8605e8 | KMS Key Arn for Encrypting logs and session |
+| iam\_policy\_arn | arn:aws:iam::123456789012:policy/ssm\_s3\_cwl\_kms\_access | IAM Policy for EC2 instances |
+| iam\_role\_arn | arn:aws:iam::123456789012:role/ssm\_role | IAM Role for EC2 instances |
+| iam\_profile\_name | ssm\_profile | EC2 instance profile for SSM |
+| ssm\_security\_group | ["sg-05e4f4cf12db5a191"] | Security Group used to access VPC Endpoints |
+| vpc\_endpoint\_ssm | ["vpce-0cefc23e81d365733"] | VPC Endpoint for SSM |
+| vpc\_endpoint\_ec2messages | ["vpce-0f507468fb9b06b8b"] | VPC Endpoint for EC2 Messages |
+| vpc\_endpoint\_ssmmessages | ["vpce-0fe2cb670d40ec053"] | VPC Endpoint for SSM Messages |
+| vpc\_endpoint\_s3 | ["vpce-0a8ebde94fa301a4a"] | VPC Endpoint for S3 |
+| vpc\_endpoint\_logs | ["vpce-08c90d8df9ef37f90"] | VPC Endpoint for CloudWatch Logs |
+| vpc\_endpoint\_kms | ["vpce-07ddc11beac1d4a3f"] | VPC Endpoint for KMS |
 
 ## SSM Usage Example
 
-* Launch an instance using the ssm_profile created by Terraform
+* Launch an instance using the ssm\_profile created by Terraform
 * Install the session-manager-plugin and start a session
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Below is a list of this modules input values:
 | access\_log\_bucket\_name | my-session-access-logs | S3 bucket for S3 access logs |
 | cloudwatch\_log\_group\_arn | arn:aws:logs:us-west-2:123456789012:log-group:/ssm/session-logs:\* | CloudWatch Log group for session logs |
 | kms\_key\_arn | arn:aws:kms:us-west-2:123456789012:key/2320fbba-d4e5-420d-82d3-1a4d6b8605e8 | KMS Key Arn for Encrypting logs and session |
-| iam\_policy\_arn | arn:aws:iam::123456789012:policy/ssm\_s3\_cwl\_kms\_access | IAM Policy for EC2 instances |
-| iam\_role\_arn | arn:aws:iam::123456789012:role/ssm\_role | IAM Role for EC2 instances |
-| iam\_profile\_name | ssm\_profile | EC2 instance profile for SSM |
+| iam\_policy\_arn | arn:aws:iam::123456789012:policy/ssm\_s3\_cwl\_kms\_access\_us-east-1 | IAM Policy for EC2 instances |
+| iam\_role\_arn | arn:aws:iam::123456789012:role/ssm\_role\_us-east-1 | IAM Role for EC2 instances |
+| iam\_profile\_name | ssm\_profile\_us-east-1 | EC2 instance profile for SSM |
 | ssm\_security\_group | ["sg-05e4f4cf12db5a191"] | Security Group used to access VPC Endpoints |
 | vpc\_endpoint\_ssm | ["vpce-0cefc23e81d365733"] | VPC Endpoint for SSM |
 | vpc\_endpoint\_ec2messages | ["vpce-0f507468fb9b06b8b"] | VPC Endpoint for EC2 Messages |

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ DOC
 
 # Create EC2 Instance Role
 resource "aws_iam_role" "ssm_role" {
-  name        = "ssm_role"
+  name        = "ssm_role_${data.aws_region.current.name}"
   description = "Allows access to SSM resources"
   path        = "/"
   tags        = var.tags
@@ -266,7 +266,7 @@ data "aws_iam_policy_document" "ssm_s3_cwl_kms_access" {
 }
 
 resource "aws_iam_policy" "ssm_s3_cwl_kms_access" {
-  name        = "ssm_s3_cwl_kms_access"
+  name        = "ssm_s3_cwl_kms_access_${data.aws_region.current.name}"
   description = "Allows access to SSM resources"
   path        = "/"
   policy      = data.aws_iam_policy_document.ssm_s3_cwl_kms_access.json
@@ -283,7 +283,7 @@ resource "aws_iam_role_policy_attachment" "SSM-s3-cwl-kms-policy-attach" {
 }
 
 resource "aws_iam_instance_profile" "ssm_profile" {
-  name = "ssm_profile"
+  name = "ssm_profile_${data.aws_region.current.name}"
   role = aws_iam_role.ssm_role.name
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "iam_role_arn" {
 }
 
 output "iam_profile_name" {
-  description = "Security Group used to access VPC Endpoints"
+  description = "EC2 instance profile for SSM"
   value       = aws_iam_instance_profile.ssm_profile.name
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,51 +1,80 @@
 output "session_logs_bucket_name" {
-  value = aws_s3_bucket.session_logs_bucket.id
+  description = "S3 bucket for session logs"
+  value       = concat(aws_s3_bucket.session_logs_bucket.*.id, [""])[0]
 }
 
 output "access_log_bucket_name" {
-  value = aws_s3_bucket.access_log_bucket.id
+  description = "S3 bucket for S3 access logs"
+  value       = concat(aws_s3_bucket.access_log_bucket.*.id, [""])[0]
 }
 
 output "cloudwatch_log_group_arn" {
-  value = aws_cloudwatch_log_group.session_manager_log_group.arn
+  description = "CloudWatch Log group for session logs"
+  value       = concat(aws_cloudwatch_log_group.session_manager_log_group.*.arn, [""])[0]
 }
 
 output "kms_key_arn" {
-  value = aws_kms_key.ssmkey.arn
+  description = "KMS Key Arn for Encrypting logs and session"
+  value       = aws_kms_key.ssmkey.arn
+}
+
+output "iam_policy_arn" {
+  description = "IAM Policy for EC2 instances"
+  value       = aws_iam_policy.ssm_s3_cwl_kms_access.arn
 }
 
 output "iam_role_arn" {
-  value = aws_iam_role.ssm_role.arn
+  description = "EC2 instance profile for SSM"
+  value       = aws_iam_role.ssm_role.arn
 }
 
 output "iam_profile_name" {
-  value = aws_iam_instance_profile.ssm_profile.name
+  description = "Security Group used to access VPC Endpoints"
+  value       = aws_iam_instance_profile.ssm_profile.name
+}
+
+output "document_name" {
+  description = "Name of the created document"
+  value       = aws_ssm_document.session_manager_prefs.name
+}
+
+output "document_arn" {
+  description = "ARN of the created document. This can be used to create IAM policies that prevent changes to session manager preferences"
+  value       = aws_ssm_document.session_manager_prefs.arn
 }
 
 output "ssm_security_group" {
-  value = aws_security_group.ssm_sg.*.id
+  description = "Security Group used to access VPC Endpoints"
+  value       = aws_security_group.ssm_sg.*.id
 }
 
 output "vpc_endpoint_ssm" {
-  value = aws_vpc_endpoint.ssm.*.id
+  description = "VPC Endpoint for SSM"
+  value       = aws_vpc_endpoint.ssm.*.id
 }
 
 output "vpc_endpoint_ec2messages" {
-  value = aws_vpc_endpoint.ec2messages.*.id
+  description = "VPC Endpoint for EC2 Messages"
+  value       = aws_vpc_endpoint.ec2messages.*.id
 }
 
 output "vpc_endpoint_ssmmessages" {
-  value = aws_vpc_endpoint.ssmmessages.*.id
+  description = "VPC Endpoint for SSM Messages"
+  value       = aws_vpc_endpoint.ssmmessages.*.id
 }
 
 output "vpc_endpoint_s3" {
-  value = aws_vpc_endpoint.s3.*.id
+  description = "VPC Endpoint for S3"
+  value       = aws_vpc_endpoint.s3.*.id
 }
 
 output "vpc_endpoint_logs" {
-  value = aws_vpc_endpoint.logs.*.id
+  description = "VPC Endpoint for CloudWatch Logs"
+  value       = aws_vpc_endpoint.logs.*.id
 }
 
 output "vpc_endpoint_kms" {
-  value = aws_vpc_endpoint.kms.*.id
+  description = "VPC Endpoint for KMS"
+  value       = aws_vpc_endpoint.kms.*.id
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,13 @@
 variable "bucket_name" {
   description = "Name of S3 bucket to store session logs"
   type        = string
+  default     = ""
+}
+
+variable "bucket_key_prefix" {
+  description = "Name of S3 sub-folder (prefix)"
+  type        = string
+  default     = ""
 }
 
 variable "log_archive_days" {
@@ -18,6 +25,7 @@ variable "log_expire_days" {
 variable "access_log_bucket_name" {
   description = "Name of S3 bucket to store access logs from session logs bucket"
   type        = string
+  default     = ""
 }
 
 variable "access_log_expire_days" {
@@ -27,7 +35,7 @@ variable "access_log_expire_days" {
 }
 
 variable "kms_key_deletion_window" {
-  description = "Waiting period for scheduled KMS Key deletion.  Can be 7-30 days."
+  description = "Number of days to wait for scheduled KMS Key deletion [7-30]"
   type        = number
   default     = 7
 }
@@ -48,6 +56,30 @@ variable "cloudwatch_log_group_name" {
   description = "Name of the CloudWatch Log Group for storing SSM Session Logs"
   type        = string
   default     = "/ssm/session-logs"
+}
+
+variable "idle_session_timeout" {
+  description = "Number of minutes a user can be inactive before a session ends [1-60]"
+  type        = number
+  default     = 20
+}
+
+variable "run_as_default_user" {
+  description = "OS default user name, if IAM user/role 'SSMSessionRunAs' tag is undefined"
+  type        = string
+  default     = "ssm-user"
+}
+
+variable "shell_profile_windows" {
+  description = "Environment variables, shell preferences, or commands to run when session starts"
+  type        = string
+  default     = ""
+}
+
+variable "shell_profile_linux" {
+  description = "Environment variables, shell preferences, or commands to run when session starts"
+  type        = string
+  default     = ""
 }
 
 variable "tags" {
@@ -72,6 +104,12 @@ variable "enable_log_to_cloudwatch" {
   description = "Enable Session Manager to Log to CloudWatch Logs"
   type        = bool
   default     = true
+}
+
+variable "enable_run_as" {
+  description = "Enable Run As support for Linux instances"
+  type        = bool
+  default     = false
 }
 
 variable "vpc_endpoints_enabled" {

--- a/vpce.tf
+++ b/vpce.tf
@@ -13,7 +13,7 @@ data "aws_route_table" "selected" {
   subnet_id = sort(data.aws_subnet_ids.selected[0].ids)[count.index]
 }
 
-# Create VPC Endpoints For Session Manager 
+# Create VPC Endpoints For Session Manager
 resource "aws_security_group" "ssm_sg" {
   count       = var.vpc_endpoints_enabled ? 1 : 0
   name        = "ssm-sg"
@@ -92,7 +92,7 @@ resource "aws_vpc_endpoint" "s3" {
   tags         = var.tags
 }
 
-# Associate S3 Gateway Endpoint to VPC and Subnets 
+# Associate S3 Gateway Endpoint to VPC and Subnets
 resource "aws_vpc_endpoint_route_table_association" "private_s3_route" {
   count           = var.vpc_endpoints_enabled && var.enable_log_to_s3 ? 1 : 0
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id

--- a/vpce.tf
+++ b/vpce.tf
@@ -8,11 +8,6 @@ data "aws_subnet_ids" "selected" {
   vpc_id = var.vpc_id
 }
 
-locals {
-  subnet_ids_string = join(",", data.aws_subnet_ids.selected[0].ids)
-  subnet_ids_list   = split(",", local.subnet_ids_string)
-}
-
 data "aws_route_table" "selected" {
   count     = var.vpc_endpoints_enabled ? length(data.aws_subnet_ids.selected[0].ids) : 0
   subnet_id = sort(data.aws_subnet_ids.selected[0].ids)[count.index]


### PR DESCRIPTION
- all changes backwards compatible
- cleanup (trailing spaces, formatting, removed unused entities)
- all resources created dynamically using `count` or `for_each` depending on module configuration
- added outputs descriptions
- added new variables/module options to better cover SSM preferences : `bucket_key_prefix`, `idle_session_timeout`, `run_as_default_user`, `shell_profile_windows`, `shell_profile_linux`, `enable_run_as`
- added new outputs: `iam_policy_arn`, `document_name`, `document_arn`
- updated `README.md` accordingly, added `Requirements`, `Providers` and `Notes` sections
- addressed https://github.com/bridgecrewio/terraform-aws-session-manager/issues/2 by removing unused code blocks