### PR TITLE
use name prefixes & condition local vars

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "bucket_name" {
-  description = "Name of S3 bucket to store session logs"
+  description = "Name prefix of S3 bucket to store session logs"
   type        = string
 }
 
@@ -16,7 +16,7 @@ variable "log_expire_days" {
 }
 
 variable "access_log_bucket_name" {
-  description = "Name of S3 bucket to store access logs from session logs bucket"
+  description = "Name prefix of S3 bucket to store access logs from session logs bucket"
   type        = string
 }
 
@@ -33,7 +33,7 @@ variable "kms_key_deletion_window" {
 }
 
 variable "kms_key_alias" {
-  description = "Alias of the KMS key.  Must start with alias/ followed by a name"
+  description = "Alias prefix of the KMS key.  Must start with alias/ followed by a name"
   type        = string
   default     = "alias/ssm-key"
 }

--- a/vpce.tf
+++ b/vpce.tf
@@ -9,7 +9,7 @@ data "aws_subnet_ids" "selected" {
 }
 
 locals {
-  subnet_ids_string = join(",", data.aws_subnet_ids.selected[0].ids)
+  subnet_ids_string = var.vpc_endpoints_enabled ? join(",", data.aws_subnet_ids.selected[0].ids) : ""
   subnet_ids_list   = split(",", local.subnet_ids_string)
 }
 
@@ -18,7 +18,7 @@ data "aws_route_table" "selected" {
   subnet_id = sort(data.aws_subnet_ids.selected[0].ids)[count.index]
 }
 
-# Create VPC Endpoints For Session Manager 
+# Create VPC Endpoints For Session Manager
 resource "aws_security_group" "ssm_sg" {
   count       = var.vpc_endpoints_enabled ? 1 : 0
   name        = "ssm-sg"
@@ -97,7 +97,7 @@ resource "aws_vpc_endpoint" "s3" {
   tags         = var.tags
 }
 
-# Associate S3 Gateway Endpoint to VPC and Subnets 
+# Associate S3 Gateway Endpoint to VPC and Subnets
 resource "aws_vpc_endpoint_route_table_association" "private_s3_route" {
   count           = var.vpc_endpoints_enabled && var.enable_log_to_s3 ? 1 : 0
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id


### PR DESCRIPTION
use name prefixes where possible. this will allow for terraform workspaces

also, fixed a small bug where local var was failing to populate when not using vpc endpoints:

```
 Error: Invalid index
│
│   on .terraform/modules/session-manager/vpce.tf line 12, in locals:
│   12:   subnet_ids_string = var.vpc_endpoints_enabled ? "" : join(",", data.aws_subnet_ids.selected[0].ids)
```