### PR TITLE
remove locals not used

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,7 @@ resource "aws_kms_alias" "ssmkey" {
 }
 
 resource "aws_cloudwatch_log_group" "session_manager_log_group" {
+  count = var.enable_log_to_cloudwatch ? 1 : 0  
   name              = var.cloudwatch_log_group_name
   retention_in_days = var.cloudwatch_logs_retention
   kms_key_id        = aws_kms_key.ssmkey.arn

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_kms_alias" "ssmkey" {
 }
 
 resource "aws_cloudwatch_log_group" "session_manager_log_group" {
-  count = var.enable_log_to_cloudwatch ? 1 : 0  
+  count             = var.enable_log_to_cloudwatch ? 1 : 0  
   name              = var.cloudwatch_log_group_name
   retention_in_days = var.cloudwatch_logs_retention
   kms_key_id        = aws_kms_key.ssmkey.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "access_log_bucket_name" {
 }
 
 output "cloudwatch_log_group_arn" {
-  value = aws_cloudwatch_log_group.session_manager_log_group.arn
+  value = aws_cloudwatch_log_group.session_manager_log_group.*.arn
 }
 
 output "kms_key_arn" {

--- a/vpce.tf
+++ b/vpce.tf
@@ -8,11 +8,6 @@ data "aws_subnet_ids" "selected" {
   vpc_id = var.vpc_id
 }
 
-locals {
-  subnet_ids_string = join(",", data.aws_subnet_ids.selected[0].ids)
-  subnet_ids_list   = split(",", local.subnet_ids_string)
-}
-
 data "aws_route_table" "selected" {
   count     = var.vpc_endpoints_enabled ? length(data.aws_subnet_ids.selected[0].ids) : 0
   subnet_id = sort(data.aws_subnet_ids.selected[0].ids)[count.index]


### PR DESCRIPTION
If I disable vpc endpoints

`vpc_endpoints_enabled     = false`

I get the error listed below.  These local vars are not used at all and can be removed.

```
Error: Invalid index

  on vpce.tf line 12, in locals:
  12:   subnet_ids_string = join(",", data.aws_subnet_ids.selected[0].ids)
    |----------------
    | data.aws_subnet_ids.selected is empty tuple
```