### PR TITLE
Get region from vpc

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -125,11 +125,10 @@ data "aws_iam_policy_document" "ssm_s3_cwl_access" {
 
     resources = [aws_kms_key.ssmkey.arn]
   }
-
 }
 
 resource "aws_iam_policy" "ssm_s3_cwl_access" {
-  name_prefix = "ssm_s3_cwl_access-"
+  name = "ssm_s3_cwl_access-${local.region}"
   path        = "/"
   policy      = data.aws_iam_policy_document.ssm_s3_cwl_access.json
 }

--- a/iam.tf
+++ b/iam.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "kms_access" {
     sid = "CloudWatchLogsEncryption"
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${local.region}.amazonaws.com"]
     }
     actions = [
       "kms:Encrypt*",

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,10 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+locals {
+  region = var.vpc_endpoints_enabled && var.vpc_id != null ? split(":",data.aws_vpc.selected[0].arn)[3] : data.aws_region.current.name
+}
+
 data "aws_partition" "current" {}
 resource "aws_kms_key" "ssmkey" {
   description             = "SSM Key"

--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,6 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-locals {
-  region = var.vpc_endpoints_enabled && var.vpc_id != null ? split(":",data.aws_vpc.selected[0].arn)[3] : data.aws_region.current.name
-}
-
 data "aws_partition" "current" {}
 resource "aws_kms_key" "ssmkey" {
   description             = "SSM Key"

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,12 @@ variable "subnet_ids" {
   default     = []
 }
 
+variable "vpc_endpoint_private_dns_enabled" {
+  description = "Enable private dns for endpoints"
+  type        = bool
+  default     = true
+}
+
 variable "enable_log_to_s3" {
   description = "Enable Session Manager to Log to S3"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "subnet_ids" {
+  description = "Subnet Ids to deploy endpoints into"
+  type        = set(string)
+  default     = []
+}
+
 variable "enable_log_to_s3" {
   description = "Enable Session Manager to Log to S3"
   type        = bool

--- a/vpce.tf
+++ b/vpce.tf
@@ -16,7 +16,7 @@ resource "aws_vpc_endpoint" "ssm" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
   subnet_ids        = data.aws_subnet_ids.selected[0].ids
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  service_name      = "com.amazonaws.${local.region}.ssm"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
@@ -31,7 +31,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
   subnet_ids        = data.aws_subnet_ids.selected[0].ids
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  service_name      = "com.amazonaws.${local.region}.ec2messages"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
@@ -46,7 +46,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
   subnet_ids        = data.aws_subnet_ids.selected[0].ids
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  service_name      = "com.amazonaws.${local.region}.ssmmessages"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
@@ -61,7 +61,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 resource "aws_vpc_endpoint" "s3" {
   count        = var.vpc_endpoints_enabled && var.enable_log_to_s3 ? 1 : 0
   vpc_id       = var.vpc_id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${local.region}.s3"
   tags         = var.tags
 }
 
@@ -84,7 +84,7 @@ resource "aws_vpc_endpoint" "logs" {
   count             = var.vpc_endpoints_enabled && var.enable_log_to_cloudwatch ? 1 : 0
   vpc_id            = var.vpc_id
   subnet_ids        = data.aws_subnet_ids.selected[0].ids
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.logs"
+  service_name      = "com.amazonaws.${local.region}.logs"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
@@ -100,7 +100,7 @@ resource "aws_vpc_endpoint" "kms" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
   subnet_ids        = data.aws_subnet_ids.selected[0].ids
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.kms"
+  service_name      = "com.amazonaws.${local.region}.kms"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [

--- a/vpce.tf
+++ b/vpce.tf
@@ -25,7 +25,7 @@ resource "aws_vpc_endpoint" "ssm" {
     aws_security_group.ssm_sg[0].id
   ]
 
-  private_dns_enabled = true
+  private_dns_enabled = var.vpc_endpoint_private_dns_enabled
   tags                = var.tags
 }
 
@@ -40,7 +40,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
     aws_security_group.ssm_sg[0].id,
   ]
 
-  private_dns_enabled = true
+  private_dns_enabled = var.vpc_endpoint_private_dns_enabled
   tags                = var.tags
 }
 
@@ -55,7 +55,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
     aws_security_group.ssm_sg[0].id,
   ]
 
-  private_dns_enabled = true
+  private_dns_enabled = var.vpc_endpoint_private_dns_enabled
   tags                = var.tags
 }
 
@@ -80,7 +80,6 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3_subnet_route" {
   route_table_id  = data.aws_route_table.selected[count.index].id
 }
 
-
 # To write session logs to CloudWatch, a CloudWatch endpoint is needed
 resource "aws_vpc_endpoint" "logs" {
   count             = var.vpc_endpoints_enabled && var.enable_log_to_cloudwatch ? 1 : 0
@@ -93,7 +92,7 @@ resource "aws_vpc_endpoint" "logs" {
     aws_security_group.ssm_sg[0].id
   ]
 
-  private_dns_enabled = true
+  private_dns_enabled = var.vpc_endpoint_private_dns_enabled
   tags                = var.tags
 }
 
@@ -109,6 +108,6 @@ resource "aws_vpc_endpoint" "kms" {
     aws_security_group.ssm_sg[0].id
   ]
 
-  private_dns_enabled = true
+  private_dns_enabled = var.vpc_endpoint_private_dns_enabled
   tags                = var.tags
 }

--- a/vpce.tf
+++ b/vpce.tf
@@ -1,4 +1,7 @@
-
+locals {
+  region = var.vpc_endpoints_enabled && var.vpc_id != null ? split(":",data.aws_vpc.selected[0].arn)[3] : data.aws_region.current.name
+  subnets = var.vpc_endpoints_enabled ? var.subnet_ids != [] ? var.subnet_ids : data.aws_subnet_ids.selected[0].ids : []
+}
 
 data "aws_subnet_ids" "selected" {
   count  = var.vpc_endpoints_enabled ? 1 : 0
@@ -6,16 +9,15 @@ data "aws_subnet_ids" "selected" {
 }
 
 data "aws_route_table" "selected" {
-  count     = var.vpc_endpoints_enabled ? length(data.aws_subnet_ids.selected[0].ids) : 0
-  subnet_id = sort(data.aws_subnet_ids.selected[0].ids)[count.index]
+  count     = var.vpc_endpoints_enabled ? length(local.subnets) : 0
+  subnet_id = sort(local.subnets)[count.index]
 }
-
 
 # SSM, EC2Messages, and SSMMessages endpoints are required for Session Manager
 resource "aws_vpc_endpoint" "ssm" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
-  subnet_ids        = data.aws_subnet_ids.selected[0].ids
+  subnet_ids        = local.subnets
   service_name      = "com.amazonaws.${local.region}.ssm"
   vpc_endpoint_type = "Interface"
 
@@ -30,7 +32,7 @@ resource "aws_vpc_endpoint" "ssm" {
 resource "aws_vpc_endpoint" "ec2messages" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
-  subnet_ids        = data.aws_subnet_ids.selected[0].ids
+  subnet_ids        = local.subnets
   service_name      = "com.amazonaws.${local.region}.ec2messages"
   vpc_endpoint_type = "Interface"
 
@@ -45,7 +47,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
 resource "aws_vpc_endpoint" "ssmmessages" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
-  subnet_ids        = data.aws_subnet_ids.selected[0].ids
+  subnet_ids        = local.subnets
   service_name      = "com.amazonaws.${local.region}.ssmmessages"
   vpc_endpoint_type = "Interface"
 
@@ -83,7 +85,7 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3_subnet_route" {
 resource "aws_vpc_endpoint" "logs" {
   count             = var.vpc_endpoints_enabled && var.enable_log_to_cloudwatch ? 1 : 0
   vpc_id            = var.vpc_id
-  subnet_ids        = data.aws_subnet_ids.selected[0].ids
+  subnet_ids        = local.subnets
   service_name      = "com.amazonaws.${local.region}.logs"
   vpc_endpoint_type = "Interface"
 
@@ -99,7 +101,7 @@ resource "aws_vpc_endpoint" "logs" {
 resource "aws_vpc_endpoint" "kms" {
   count             = var.vpc_endpoints_enabled ? 1 : 0
   vpc_id            = var.vpc_id
-  subnet_ids        = data.aws_subnet_ids.selected[0].ids
+  subnet_ids        = local.subnets
   service_name      = "com.amazonaws.${local.region}.kms"
   vpc_endpoint_type = "Interface"
 


### PR DESCRIPTION
Can pass in the region
Can pass in the subnet ids to use (its very common to have other subnets we don't want to use private vs public subnets)
Can configure if private dns is enabled or not
Generate a stable id ssm_s3_cwl_access so that the policy can be referenced easily 

Fixes #12 