### PR TITLE
Resolved `aws_subnet_ids` deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ No modules.
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
-| [aws_subnet_ids.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/vpce.tf
+++ b/vpce.tf
@@ -1,11 +1,14 @@
 locals {
   region  = var.vpc_endpoints_enabled && var.vpc_id != null ? split(":", data.aws_vpc.selected[0].arn)[3] : data.aws_region.current.name
-  subnets = var.vpc_endpoints_enabled ? var.subnet_ids != [] ? var.subnet_ids : data.aws_subnet_ids.selected[0].ids : []
+  subnets = var.vpc_endpoints_enabled ? var.subnet_ids != [] ? var.subnet_ids : data.aws_subnets.selected.ids[0] : []
 }
 
-data "aws_subnet_ids" "selected" {
-  count  = var.vpc_endpoints_enabled ? 1 : 0
-  vpc_id = var.vpc_id
+data "aws_subnets" "selected" {
+  count = var.vpc_endpoints_enabled ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
 }
 
 data "aws_route_table" "selected" {

--- a/vpce.tf
+++ b/vpce.tf
@@ -1,6 +1,6 @@
 locals {
   region  = var.vpc_endpoints_enabled && var.vpc_id != null ? split(":", data.aws_vpc.selected[0].arn)[3] : data.aws_region.current.name
-  subnets = var.vpc_endpoints_enabled ? var.subnet_ids != [] ? var.subnet_ids : data.aws_subnets.selected.ids[0] : []
+  subnets = var.vpc_endpoints_enabled ? var.subnet_ids != [] ? var.subnet_ids : data.aws_subnets.selected[0].ids : []
 }
 
 data "aws_subnets" "selected" {


### PR DESCRIPTION
Note: changes are untested and should be reviewed before merge.

This PR updates the data resource that provides AWS subnet IDs. This change removes the deprecation warning caused by the old resource type.

Issue is described in #22 .